### PR TITLE
Happy new year!

### DIFF
--- a/snaked/core/config.py
+++ b/snaked/core/config.py
@@ -31,6 +31,9 @@ class SnakedConf(prefs.PySettings):
     PANEL_HEIGHT = 200
     PANEL_HEIGHT_DOC = "Console, test and other panels height"
 
+    CONSOLE_FONT = "Mono 8"
+    CONSOLE_FONT_DOC = "Font used for console display"
+
 def add_option(name, default, doc=None):
     setattr(SnakedConf, name, default)
     if doc:

--- a/snaked/core/console.py
+++ b/snaked/core/console.py
@@ -28,7 +28,6 @@ def create_console_widget():
     panel.view = gtk.TextView()
     panel.view.set_editable(False)
     panel.view.set_buffer(gtk.TextBuffer())
-    panel.view.modify_font(pango.FontDescription('Mono'))
     panel.add(panel.view)
     panel.view.show()
 
@@ -48,6 +47,8 @@ def hide(editor, widget, escape):
     editor.view.grab_focus()
 
 def on_console_popup(widget, editor):
+    if editor.snaked_conf['CONSOLE_FONT']:
+        widget.view.modify_font(pango.FontDescription(editor.snaked_conf['CONSOLE_FONT']))
     widget.escape = Escape()
     editor.push_escape(hide, widget, widget.escape)
 

--- a/snaked/core/console.py
+++ b/snaked/core/console.py
@@ -1,5 +1,6 @@
 import gtk
 import glib
+import pango
 
 from snaked.util import refresh_gui
 
@@ -27,6 +28,7 @@ def create_console_widget():
     panel.view = gtk.TextView()
     panel.view.set_editable(False)
     panel.view.set_buffer(gtk.TextBuffer())
+    panel.view.modify_font(pango.FontDescription('Mono'))
     panel.add(panel.view)
     panel.view.show()
 

--- a/snaked/core/manager.py
+++ b/snaked/core/manager.py
@@ -40,7 +40,7 @@ class EditorManager(object):
             'editor', 'font', 'style', 'margin', 'line', 'tab', 'whitespace')
 
         prefs.register_dialog('Global preferences', self.show_global_preferences,
-            'snaked', 'preferences')
+            'snaked', 'global', 'preferences')
 
         prefs.register_dialog('Session preferences', self.show_session_preferences,
             'session', 'preferences')

--- a/snaked/core/run.py
+++ b/snaked/core/run.py
@@ -40,7 +40,7 @@ def get_manager():
     options, args = parser.parse_args()
 
     distant = False
-    FIFO = '/tmp/snaked.io'
+    FIFO = '/tmp/snaked.io.%s'%options.session
 
     if os.path.exists(FIFO):
         try:
@@ -55,10 +55,8 @@ def get_manager():
             except OSError:
                 pass
 
-    print distant
-
-
     if distant:
+        print "Transmitting file information to snaked"
         for fname in args:
             msg = "FILE:%s\n"%os.path.abspath(fname)
             out_descr.write('%05d%s'%(len(msg), msg))
@@ -66,7 +64,6 @@ def get_manager():
     else:
         os.mkfifo(FIFO)
         out_descr = open(FIFO, 'r+')
-
 
     import gobject
     gobject.threads_init()

--- a/snaked/plugins/python/plugin.py
+++ b/snaked/plugins/python/plugin.py
@@ -269,7 +269,7 @@ class Plugin(object):
         source, offset = self.get_source_and_offset()
 
         # make foo.bar.baz( equivalent to foo.bar.baz
-        if source[offset-1] == '(':
+        if source[offset-1] in '(.':
             offset -= 1
 
         brackets = get_brackets(source, offset)

--- a/snaked/plugins/python/plugin.py
+++ b/snaked/plugins/python/plugin.py
@@ -268,6 +268,10 @@ class Plugin(object):
 
         source, offset = self.get_source_and_offset()
 
+        # make foo.bar.baz( equivalent to foo.bar.baz
+        if source[offset-1] == '(':
+            offset -= 1
+
         brackets = get_brackets(source, offset)
         if brackets:
             br, spos, epos = brackets


### PR DESCRIPTION
Hi!
Here is a minor contribution, to allow calltips on symbols ending with a "." or a "(" .

"os." will return the same doc as "os", "os.listdir(" the same as "os.listdir" etc...

Unfortunately there is a weired bug, maybe in rope, that prevents things like os.path (or os.path.*) to be documented, but this is an old bug.
